### PR TITLE
fix: vLLM 서버 안정성 개선,supervisord 재시작 정책 수정

### DIFF
--- a/scripts/direct_vllm_start.sh
+++ b/scripts/direct_vllm_start.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# vLLM 서버 직접 시작 스크립트
+# 배포 환경에서 안정적인 실행을 위한 백업 방안
+
+echo "=== vLLM 직접 시작 스크립트 ==="
+echo "모델: ${VLLM_MODEL_PATH:-haebo/meow-clovax-v2}"
+echo "포트: ${VLLM_PORT:-8001}"
+
+# 환경 변수 설정
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-max_split_size_mb:128}
+
+# 최대 재시도 횟수
+MAX_RETRIES=3
+RETRY_COUNT=0
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    echo "vLLM 서버 시작 시도 ($((RETRY_COUNT + 1))/$MAX_RETRIES)..."
+    
+    python -m vllm.entrypoints.openai.api_server \
+        --model "${VLLM_MODEL_PATH:-haebo/meow-clovax-v2}" \
+        --host "${VLLM_HOST:-0.0.0.0}" \
+        --port "${VLLM_PORT:-8001}" \
+        --served-model-name "${VLLM_SERVED_MODEL_NAME:-meow-clovax-v2}" \
+        --gpu-memory-utilization "${VLLM_GPU_MEMORY_UTILIZATION:-0.8}" \
+        --max-model-len "${VLLM_MAX_MODEL_LEN:-1536}" \
+        --max-num-seqs "${VLLM_MAX_NUM_SEQS:-12}" \
+        --disable-log-requests \
+        --trust-remote-code
+    
+    EXIT_CODE=$?
+    
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "vLLM 서버가 정상 종료되었습니다"
+        break
+    else
+        echo "vLLM 서버 오류 발생 (exit code: $EXIT_CODE)"
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+        
+        if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+            echo "10초 후 재시도합니다..."
+            sleep 10
+        fi
+    fi
+done
+
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    echo "vLLM 서버 시작 실패: 최대 재시도 횟수 초과"
+    exit 1
+fi 


### PR DESCRIPTION
## 🔧 vLLM 서버 안정성 개선 및 배포 환경 최적화

### 📋 문제 상황
배포 환경에서 vLLM 서버가 계속 재시작하며 FATAL 상태에 빠지는 문제 발생:
- `INFO exited: vllm (exit status 0; not expected)`
- `INFO gave up: vllm entered FATAL state, too many start retries too quickly`
- 포트 충돌로 인한 서버 시작 실패

### ✅ 해결 방안

#### 1. supervisord 설정 개선
- **재시작 정책 변경**: `autorestart=false`로 무한 재시작 방지
- **재시도 횟수 제한**: `startretries=1`로 설정
- **우선순위 설정**: vLLM(100) → FastAPI(200) 순서로 시작

#### 2. 직접 vLLM 실행 스크립트 추가
```bash
scripts/direct_vllm_start.sh
```
- 3회 재시도 로직 내장
- 상세한 오류 로깅
- 환경변수 기반 설정
- 안정적인 bash 스크립트 방식

#### 3. Docker 설정 최적화
- 스크립트 실행 권한 자동 부여
- supervisord에서 Python 모듈 대신 bash 스크립트 실행