### PR TITLE
fix : vllm 포트변경 8001 to 8002

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN chmod +x /app/scripts/gpu_cache_cleanup.sh
 ENV PYTHONPATH=/app \
     VLLM_MODEL_PATH="haebo/meow-clovax-v3" \
     VLLM_HOST="0.0.0.0" \
-    VLLM_PORT="8001" \
+    VLLM_PORT="8002" \
     VLLM_SERVED_MODEL_NAME="meow-clovax-v3" \
     VLLM_GPU_MEMORY_UTILIZATION="0.4" \
     VLLM_MAX_MODEL_LEN="512" \
@@ -77,7 +77,7 @@ ENV PYTHONPATH=/app \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-EXPOSE 8000 8001
+EXPOSE 8000 8002
 
 # 헬스체크
 HEALTHCHECK --interval=60s --timeout=15s --start-period=120s --retries=2 \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python scripts/model_manager.py start
 **동작 과정:**
 - 허깅페이스에서 모델 자동 다운로드 (첫 실행 시)
 - `haebo/meow-clovax-v3` 모델 로드
-- 서버 실행: http://localhost:8001
+- 서버 실행: http://localhost:8002
 
 ### 2단계: FastAPI 서버 시작 (새 터미널 2)
 ```bash
@@ -214,7 +214,7 @@ docker-compose up -d
 
 # 또는 개별 빌드 및 실행
 docker build -t meow-ai .
-docker run -p 8000:8000 -p 8001:8001 --gpus all meow-ai
+docker run -p 8000:8000 -p 8002:8002 --gpus all meow-ai
 ```
 
 ## 🧪 테스트

--- a/ai_server/external/vLLM/client/vllm_client.py
+++ b/ai_server/external/vLLM/client/vllm_client.py
@@ -23,7 +23,7 @@ class CompletionRequest(BaseModel):
 class VLLMAsyncClient:
     """간소화된 vLLM 비동기 클라이언트"""
     
-    def __init__(self, base_url: str = "http://localhost:8001"):
+    def __init__(self, base_url: str = "http://localhost:8002"):
         self.base_url = base_url.rstrip("/")
         self.model_name = "meow-clovax-v3" 
         self._client: Optional[httpx.AsyncClient] = None

--- a/ai_server/external/vLLM/server/vllm_config.py
+++ b/ai_server/external/vLLM/server/vllm_config.py
@@ -13,7 +13,7 @@ class VLLMConfig(BaseSettings):
     
     # 서버 기본 설정
     host: str = Field(default="0.0.0.0", description="vLLM 서버 호스트")
-    port: int = Field(default=8001, description="vLLM 서버 포트")
+    port: int = Field(default=8002, description="vLLM 서버 포트")
     
     # 모델 설정
     model_path: str = Field(

--- a/ai_server/model/comment_model.py
+++ b/ai_server/model/comment_model.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 # comment 변환 서비스
 class CommentTransformationService:
-    def __init__(self, vllm_base_url: str = "http://localhost:8001"):
+    def __init__(self, vllm_base_url: str = "http://localhost:8002"):
         self.vllm_base_url = vllm_base_url
         self.inference_config = get_inference_config()
         

--- a/ai_server/model/post_model.py
+++ b/ai_server/model/post_model.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 # post 변환 서비스
 class PostTransformationService:
-    def __init__(self, vllm_base_url: str = "http://localhost:8001"):
+    def __init__(self, vllm_base_url: str = "http://localhost:8002"):
         self.vllm_base_url = vllm_base_url
         self.inference_config = get_inference_config()
         

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,12 @@ services:
     container_name: meow-ai-server
     ports:
       - "8000:8000"  # FastAPI 서버
-      - "8001:8001"  # vLLM 서버
+      - "8002:8002"  # vLLM 서버
     environment:
       # vLLM 모델 설정
       VLLM_MODEL_PATH: "haebo/meow-clovax-v3"
       VLLM_HOST: "0.0.0.0"
-      VLLM_PORT: "8001"
+      VLLM_PORT: "8002"
       VLLM_SERVED_MODEL_NAME: "meow-clovax-v3"
       VLLM_GPU_MEMORY_UTILIZATION: "0.4"
       VLLM_MAX_MODEL_LEN: "512"


### PR DESCRIPTION
fix : vllm 포트변경 8001 to 8002

- 백엔드에서 요청을 8001이 아니라 8002로 보내고 있음을 확인
- 부득이 하게 vLLM의 포트 번호는 전부 8002로 변경 진행